### PR TITLE
Fix CI server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <a href='https://semaphoreci.com/nimblehq/nimble-auth'> <img src='https://semaphoreci.com/api/v1/nimblehq/nimble-auth/branches/development/badge.svg' alt='Build Status'></a>
+    <a href='https://semaphoreci.com/nimble/nimble-auth'> <img src='https://semaphoreci.com/api/v1/nimble/nimble-auth/branches/development/badge.svg' alt='Build Status'></a>
 </p>
 
 ---


### PR DESCRIPTION
## What happened

Fix URL for the CI badge as it was pointing to the wrong organization name.
 
## Insight

`N/A`
 
## Proof Of Work

![nimblehq_nimble-auth_at_chore_ci-badge](https://user-images.githubusercontent.com/696529/53294812-66b93200-3821-11e9-95d3-7adbea0eb9ad.png)
