### PR TITLE
Fix: Improve the engine configuration to work consistently with omniauth

### DIFF
--- a/app/controllers/nimble_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/nimble_auth/omniauth_callbacks_controller.rb
@@ -1,5 +1,7 @@
 module NimbleAuth
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    before_action :check_authentication_status
+
     NimbleAuth.config.omniauth_providers.each do |provider|
       define_method provider do
         authenticate
@@ -9,7 +11,7 @@ module NimbleAuth
     private
 
     def authenticate
-      auth_service = AuthenticationService.new(request.env['omniauth.auth'])
+      auth_service = AuthenticationService.new(auth_params: auth_params, auth_type: 'omniauth')
       auth_response = auth_service.call
 
       if auth_response[:status] == :ok
@@ -19,14 +21,45 @@ module NimbleAuth
       end
     end
 
-    def after_authentication_success(_auth_response)
-      # App logic goes here
-      redirect_to root_path
+    def auth_params
+      request.env['omniauth.auth']
     end
 
-    def after_authentication_failure(_auth_response)
-      # App logic goes here
-      redirect_to root_path
+    def after_authentication_success(auth_response)
+      user = auth_response[:identity].user
+
+      sign_in(user)
+
+      redirect_to after_sign_in_redirect_path(user)
+    end
+
+    def after_authentication_failure(auth_response)
+      flash[:error] = auth_response[:message]
+
+      redirect_to new_user_session_path
+    end
+
+    def check_authentication_status
+      return true if request.env['omniauth.error'].blank?
+
+      humanized_error_messages = error_message.transform_values(&:humanize)
+
+      flash[:error] = I18n.t(
+        'activerecord.errors.messages.omniauth.authentication_failure',
+        title: humanized_error_messages[:title],
+        description: humanized_error_messages[:description],
+        reason: humanized_error_messages[:reason]
+      )
+
+      redirect_to new_user_session_path
+    end
+
+    def error_message
+      {
+        title: params[:error] || '',
+        description: params[:error_description] || '',
+        reason: params[:error_reason] || ''
+      }
     end
   end
 end

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -6,3 +6,8 @@ en:
           create: Your account was created successfully.
         identity:
           create_for_existing_user: New credentials added to your existing account.
+    errors:
+      messages:
+        omniauth:
+          authentication_failure: "%{title}: %{description} due to %{reason}."
+          onboarding_failure: "An account has not been yet created for '%{email}'"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,24 +3,24 @@
 require_relative '../lib/nimble_auth/devise_custom_failure'
 
 NimbleAuth::Engine.routes.draw do
-  CUSTOM_CONTROLLERS = {
-    omniauth_callbacks: 'nimble_auth/omniauth_callbacks',
-    sessions: 'nimble_auth/sessions'
-  }.freeze
-
-  CUSTOM_PATH = {
-    sign_in: 'signin',
-    sign_up: 'signup',
-    sign_out: 'signout'
-  }.freeze
-
   if NimbleAuth.configuration.resource_class.present?
     # ==> Mount Devise Engine
     devise_for NimbleAuth.configuration.resource_class.pluralize.downcase.to_sym,
                module: :devise,
                path: '/',
                class_name: NimbleAuth.configuration.resource_class,
-               controllers: CUSTOM_CONTROLLERS,
-               path_names: CUSTOM_PATH
+               controllers: {
+                 omniauth_callbacks: 'nimble_auth/omniauth_callbacks',
+                 sessions: 'nimble_auth/sessions'
+               },
+               path_names: {
+                 sign_in: 'signin',
+                 sign_up: 'signup',
+                 sign_out: 'signout'
+               }
+
+    devise_scope :user do
+      get '/signout', to: 'sessions#destroy', as: :user_logout
+    end
   end
 end

--- a/lib/generators/templates/migrations/create_identities_table.rb
+++ b/lib/generators/templates/migrations/create_identities_table.rb
@@ -13,6 +13,6 @@ class CreateIdentities < ActiveRecord::Migration[5.1]
       t.belongs_to :user, foreign_key: true
     end
 
-    add_index :identities, [:provider, :uid], unique: true
+    add_index :identities, [:provider, :uid]
   end
 end

--- a/lib/nimble_auth/concerns/identity.rb
+++ b/lib/nimble_auth/concerns/identity.rb
@@ -1,13 +1,12 @@
 module NimbleAuth
-  module Identity
-    module_function
+  module Concerns
+    module Identity
+      extend ActiveSupport::Concern
 
-    def extend_model
-      # Extend the parent Model class
-      NimbleAuth.configuration.resource_identity_class.constantize.class_eval do
+      included do
         belongs_to :user
 
-        validates :uid, :provider, :user, presence: true
+        validates :uid, :provider, :oauth_token, presence: true
 
         class << self
           def create_for(oauth:, user:)

--- a/lib/nimble_auth/concerns/user.rb
+++ b/lib/nimble_auth/concerns/user.rb
@@ -1,13 +1,12 @@
 module NimbleAuth
-  module User
-    module_function
+  module Concerns
+    module User
+      extend ActiveSupport::Concern
 
-    def extend_model
-      # Extend the parent Model class
-      NimbleAuth.configuration.resource_class.constantize.class_eval do
+      included do
         has_many :identities, dependent: :destroy
 
-        validates :email, presence: true
+        validates :first_name, :last_name, :email, presence: true
         validates :email, uniqueness: true
 
         devise :database_authenticatable,

--- a/lib/nimble_auth/resource_setup.rb
+++ b/lib/nimble_auth/resource_setup.rb
@@ -1,0 +1,18 @@
+require_relative 'concerns/user'
+require_relative 'concerns/identity'
+
+module NimbleAuth
+  module Resource
+    module_function
+
+    # Extend the main app model User class
+    def extend_user_model
+      NimbleAuth.configuration.resource_class.constantize.send(:include, NimbleAuth::Concerns::User)
+    end
+
+    # Extend the main app model Identity class
+    def extend_identity_model
+      NimbleAuth.configuration.resource_identity_class.constantize.send(:include, NimbleAuth::Concerns::Identity)
+    end
+  end
+end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NimbleAuth.configuration.resource_identity_class.constantize, typ
   describe 'validations' do
     it { should validate_presence_of(:uid) }
     it { should validate_presence_of(:provider) }
-    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:oauth_token) }
   end
 
   describe '.create_for' do


### PR DESCRIPTION
Closes #15 

## What happened

Revisit and improve the way the engine extends the main application. 
 
## Insight

* Using `concerns` instead of `module_eval` to extend the models in the main app
* Expanded the default handling of the omniauth callbacks to make it more production-ready 
 
## Proof Of Work

This setup has been used in two project: `athena-web` and `vcliq-web`