### PR TITLE
Bump version name to 1.0.0

### DIFF
--- a/lib/nimble_auth/version.rb
+++ b/lib/nimble_auth/version.rb
@@ -1,3 +1,3 @@
 module NimbleAuth
-  VERSION = '0.1.0'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
## What happened

Just bumping the actual version name of the gem to `1.0.0`. 
 
## Insight

`N/A`
 
## Proof Of Work

`N/A`